### PR TITLE
Fixed VhostCreateCommand.php declaration error

### DIFF
--- a/src/Command/VhostCreateCommand.php
+++ b/src/Command/VhostCreateCommand.php
@@ -20,7 +20,7 @@ class VhostCreateCommand extends AbstractComposerFilesCommand
             ->setDescription('Create nginx vhosts phpXY.benchmark.loc');
     }
 
-    protected function doExecute(): parent
+    protected function doExecute(): AbstractCommand
     {
         foreach (PhpVersion::getAll() as $phpVersion) {
             $this->title('Create ' . $this->getHost($phpVersion) . ' virtual host');


### PR DESCRIPTION
While testing I stumbled on this error: PHP Fatal error:  Declaration of App\Command\VhostCreateCommand::doExecute(): App\Command\Validate\AbstractComposerFilesCommand must be compatible with App\Command\AbstractCommand::doExecute(): App\Command\AbstractCommand in /var/phpbenchmarks/Command/VhostCreateCommand.php on line 93