### PR TITLE
[4.0] Fix phpinfo host not registered

### DIFF
--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -4,6 +4,7 @@ set -e
 
 echo "127.0.0.1 benchmark-kit.loc" >> /etc/hosts
 echo "127.0.0.1 statistics.benchmark-kit.loc" >> /etc/hosts
+echo "127.0.0.1 phpinfo.benchmark-kit.loc" >> /etc/hosts
 
 service php5.6-fpm start
 service php7.0-fpm start


### PR DESCRIPTION
Hi,

In the docker entrypoint.sh file, there is a missing entry for the domain "phpinfo.benchmark-kit.loc" which lead to an error when validating the benchmark :

```
Validation of http://phpinfo.benchmark-kit.loc:8888 for PHP 7.2 with opcached disabled, preload disabled 
  >   EXCEPTION  Error while calling http://phpinfo.benchmark-kit.loc:8888: Could not resolve host: phpinfo.benchmark-kit.loc.
```

This PR quickly and simply fix this error :smiley: 