### PR TITLE
Fix statistic opcache check

### DIFF
--- a/src/Command/Validate/Benchmark/ValidateBenchmarkStatisticsCommand.php
+++ b/src/Command/Validate/Benchmark/ValidateBenchmarkStatisticsCommand.php
@@ -67,6 +67,7 @@ final class ValidateBenchmarkStatisticsCommand extends AbstractValidateBenchmark
             (new OptionsResolver())
                 ->configureRequiredOption('memory', ['array'])
                 ->configureRequiredOption('code', ['array'])
+                ->configureRequiredOption('preload', ['array'])
                 ->resolve($statistics);
 
             (new OptionsResolver())
@@ -83,6 +84,11 @@ final class ValidateBenchmarkStatisticsCommand extends AbstractValidateBenchmark
                 ->configureRequiredOption('functions', ['int'])
                 ->configureRequiredOption('constants', ['int'])
                 ->resolve($statistics['code']);
+
+            (new OptionsResolver())
+                ->configureRequiredOption('memory', ['int', 'null'])
+                ->configureRequiredOption('files', ['int', 'null'])
+                ->resolve($statistics['preload']);
         } catch (\Throwable $exception) {
             throw new \Exception('Invalid statistics JSON file format.', 0, $exception);
         }

--- a/templates/public/statistics.php.twig
+++ b/templates/public/statistics.php.twig
@@ -3,6 +3,8 @@
 require('{{ entryPointPath }}');
 
 $opcacheStatus = function_exists('opcache_get_status') ? opcache_get_status() : [];
+$opcacheStatus = is_array($opcacheStatus) ? $opcacheStatus : [];
+
 if (array_key_exists('preload_statistics', $opcacheStatus) === true) {
     $preloadMemory = $opcacheStatus['preload_statistics']['memory_consumption'];
     $preloadFiles = count($opcacheStatus['preload_statistics']['scripts']);


### PR DESCRIPTION
Hi !
A quick PR to fix an error in the statistics generation and validation.

First commit fix the template for the statistics.php file. When op_cache is disabled, the function `opcache_get_status` return `false` which can't be used in the following `array_key_exists` resulting (in my case) in an error and no statistics.json file generation.
I tried to keep the fix readable (no nested ternary) and php 5.x compliant.

The second commit fix the `validate:benchmark:statistics` command which fail to valid the Json format with the new `preload` key added. I don't really know why (and didn't searched long) but if the key `preload` is present but not in the list of `configureRequiredOption` it throw an error `The option "preload" does not exist. Defined options are: "code", "memory".`
Anyway, I fixed it by adding the `preload` key as mandatory and added the type validation which can be `int` or `null` if preload / op_cache is disabled.

Let me know ! :) 