### PR TITLE
Fix preload host registration + preload url generation

### DIFF
--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -5,6 +5,7 @@ set -e
 echo "127.0.0.1 benchmark-kit.loc" >> /etc/hosts
 echo "127.0.0.1 statistics.benchmark-kit.loc" >> /etc/hosts
 echo "127.0.0.1 phpinfo.benchmark-kit.loc" >> /etc/hosts
+echo "127.0.0.1 preload-generator.benchmark-kit.loc" >> /etc/hosts
 
 service php5.6-fpm start
 service php7.0-fpm start

--- a/phpbenchkit.sh
+++ b/phpbenchkit.sh
@@ -171,5 +171,6 @@ fi
 addHost "benchmark-kit.loc"
 addHost "phpinfo.benchmark-kit.loc"
 addHost "statistics.benchmark-kit.loc"
+addHost "preload-generator.benchmark-kit.loc"
 
 docker exec $ttyParameter --user=phpbenchmarks $CONTAINER_NAME phpbenchkit $consoleParams

--- a/src/Benchmark/BenchmarkUrlService.php
+++ b/src/Benchmark/BenchmarkUrlService.php
@@ -46,7 +46,7 @@ class BenchmarkUrlService
 
     public static function getPreloadGeneratorUrl(): string
     {
-        return 'http://' . static::PRELOAD_GENERATOR_HOST . ':' . static::getNginxPort();
+        return 'http://' . static::PRELOAD_GENERATOR_HOST . ':' . static::getNginxPort() . Benchmark::getBenchmarkRelativeUrl();
     }
 
     public static function getNginxPort(): int


### PR DESCRIPTION
Hello,

This PR fix the missing registration of the "preload-generator.benchmark-kit.loc" domain into the hosts files (host machine + container).

Secondly, it fix the preload generator URL by appending the benchmark relative URL. I used the same logic of the `getStatisticsUrl` function.
This way, the correct URL is used and displayed in order to fetch the correct class list by calling the final benchmark URL.

Let me know if everything is OK !